### PR TITLE
Topic/go eff

### DIFF
--- a/examples/Free.purs
+++ b/examples/Free.purs
@@ -12,8 +12,8 @@ instance teletypeFFunctor :: Functor TeletypeF where
 
 type Teletype = Free TeletypeF
 
-putStrLn :: String -> Teletype {}
-putStrLn s = liftF $ PutStrLn s {}
+putStrLn :: String -> Teletype Unit
+putStrLn s = liftF $ PutStrLn s unit
 
 getLine :: Teletype String
 getLine = liftF $ GetLine (\a -> a)
@@ -29,5 +29,8 @@ echo = do
   a <- getLine
   putStrLn a
   putStrLn "Finished"
+  return $ a ++ a
 
-main = run $ echo
+main = do
+  a <- run $ echo
+  trace a

--- a/src/Control/Monad/Free.purs
+++ b/src/Control/Monad/Free.purs
@@ -129,10 +129,7 @@ foreign import goEffImpl
   \  return function(){\
   \    while (true) {\
   \      var r = resume(value);\
-  \      if (isRight(r)) {\
-  \        var x = fromRight(r);\
-  \        return function() { return x; };\
-  \      }\
+  \      if (isRight(r)) return fromRight(r);\
   \      value = fn(fromLeft(r))();\
   \    }\
   \  };\


### PR DESCRIPTION
There was an extra function wrapping the `Right` result. This change should do the trick. Running the example will now trace "fake inputfake input" at the end.
