### PR TITLE
Only expose RWS functions via the appropriate classes

### DIFF
--- a/src/Control/Monad/RWS.purs
+++ b/src/Control/Monad/RWS.purs
@@ -13,7 +13,7 @@ import Data.Tuple
 -- | to the `Identity` monad.
 type RWS r w s = RWST r w s Identity
 
--- | Create an action in the `RWS` monad from a function which uses the 
+-- | Create an action in the `RWS` monad from a function which uses the
 -- | global context and state explicitly.
 rws :: forall r w s a. (r -> s -> See s a w) -> RWS r w s a
 rws f = RWST \r s -> return $ f r s
@@ -37,59 +37,3 @@ mapRWS f = mapRWST (runIdentity >>> f >>> Identity)
 -- | Change the type of the context in a `RWS` action
 withRWS :: forall r1 r2 w s a. (r2 -> s -> Tuple r1 s) -> RWS r1 w s a -> RWS r2 w s a
 withRWS = withRWST
-
--- | Get the context of a `RWS` action
-ask :: forall r w s m. (Applicative m, Monoid w) => RWST r w s m r
-ask = RWST \r s -> pure $ mkSee s r mempty
-
--- | Locally change the context of a `RWS` action.
-local :: forall  r w s m a. (r -> r) -> RWST r w s m a -> RWST r w s m a
-local f m = RWST \r s -> runRWST m (f r) s
-
--- | Read a value which depends on the context in a `RWS` action.
-reader :: forall r w s m a. (Applicative m, Monoid w) => (r -> a) -> RWST r w s m a
-reader f = RWST \r s -> pure $ mkSee s (f r) mempty
-
--- | Write to the accumulator in a `RWS` action
-writer :: forall r w s m a. (Applicative m) => Tuple a w -> RWST r w s m a
-writer (Tuple a w) = RWST \_ s -> pure $ {state: s, result: a, log: w}
-
--- | Execute a `RWS` action, and return the changes to the accumulator along with the return value
-listen :: forall r w s m a. (Monad m) => RWST r w s m a -> RWST r w s m (Tuple a w)
-listen m = RWST \r s -> runRWST m r s >>= \{state = s', result = a, log = w} -> pure $ {state: s', result: Tuple a w, log: w}
-
--- | Execute a `RWS` action and modify the accumulator
-pass :: forall r w s m a. (Monad m) => RWST r w s m (Tuple a (w -> w)) -> RWST r w s m a
-pass m = RWST \r s -> runRWST m r s >>= \{result = Tuple a f, state = s', log = w} -> pure $ {state: s', result: a, log: f w}
-
--- | Append a value to the accumulator in a `RWS` action
-tell :: forall r w s m. (Applicative m) => w -> RWST r w s m Unit
-tell w = writer (Tuple unit w)
-
--- | Execute a `RWS` action, and return a value which depends on the accumulator along with the return value
-listens :: forall r w s m a b. (Monad m) => (w -> b) -> RWST r w s m a -> RWST r w s m (Tuple a b)
-listens f m = RWST \r s -> runRWST m r s >>= \{state = s', result = a, log = w} -> pure $ {state: s', result: Tuple a (f w), log: w}
-
--- | Modify the accumulator in a `RWS` action
-censor :: forall r w s m a. (Monad m) => (w -> w) -> RWST r w s m a -> RWST r w s m a
-censor f m = RWST \r s -> runRWST m r s >>= \see -> pure $ see{log = f see.log}
-
--- | Get or modify the state in a `RWS` action
-state :: forall r w s m a. (Applicative m, Monoid w) => (s -> Tuple a s) -> RWST r w s m a
-state f = RWST \_ s -> case f s of Tuple a s' -> pure $ mkSee s' a mempty
-
--- | Get the state in a `RWS` action
-get :: forall r w s m. (Applicative m, Monoid w) => RWST r w s m s
-get = state \s -> Tuple s s
-
--- | Get a value which depends on the state in a `RWS` action
-gets :: forall r w s m a. (Applicative m, Monoid w) => (s -> a) -> RWST r w s m a
-gets f = state \s -> Tuple (f s) s
-
--- | Set the state in a `RWS` action
-put :: forall r w s m. (Applicative m, Monoid w) => s -> RWST r w s m Unit
-put s = state \_ -> Tuple unit s
-
--- | Modify the state in a `RWS` action
-modify :: forall r w s m. (Applicative m, Monoid w) => (s -> s) -> RWST r w s m Unit
-modify f = state \s -> Tuple unit (f s)

--- a/src/Control/Monad/Reader/Class.purs
+++ b/src/Control/Monad/Reader/Class.purs
@@ -14,8 +14,6 @@ import Control.Monad.State.Trans
 import Control.Monad.Writer.Trans
 import Data.Monoid
 
-import qualified Control.Monad.RWS as RWS
-
 -- | The `MonadReader` type class represents those monads which support a global context via
 -- | `ask` and `local`.
 -- |
@@ -30,7 +28,7 @@ import qualified Control.Monad.RWS as RWS
 -- | - `do { ask ; ask } = ask`
 -- | - `local f ask = f <$> ask`
 -- | - `local _ (pure a) = pure a`
--- | - `local f (do { a <- x ; y }) = do { a <- local f x ; local f y }` 
+-- | - `local f (do { a <- x ; y }) = do { a <- local f x ; local f y }`
 class MonadReader r m where
   ask :: m r
   local :: forall a. (r -> r) -> m a -> m a
@@ -64,5 +62,5 @@ instance monadReaderStateT :: (Monad m, MonadReader r m) => MonadReader r (State
   local f = mapStateT (local f)
 
 instance monadReaderRWST :: (Monad m, Monoid w) => MonadReader r (RWST r w s m) where
-  ask = RWS.ask
-  local = RWS.local
+  ask = RWST \r s -> pure $ mkSee s r mempty
+  local f m = RWST \r s -> runRWST m (f r) s

--- a/src/Control/Monad/State/Class.purs
+++ b/src/Control/Monad/State/Class.purs
@@ -15,8 +15,6 @@ import Control.Monad.Writer.Trans
 import Data.Monoid
 import Data.Tuple
 
-import qualified Control.Monad.RWS as RWS
-
 -- | The `MonadState s` type class represents those monads which support a single piece of mutable
 -- | state of type `s`.
 -- |
@@ -70,4 +68,4 @@ instance monadStateWriterT :: (Monad m, Monoid w, MonadState s m) => MonadState 
   state f = lift (state f)
 
 instance monadStateRWST :: (Monad m, Monoid w) => MonadState s (RWST r w s m) where
-  state = RWS.state
+  state f = RWST \_ s -> case f s of Tuple a s' -> pure $ mkSee s' a mempty

--- a/src/Control/Monad/Writer/Class.purs
+++ b/src/Control/Monad/Writer/Class.purs
@@ -15,8 +15,6 @@ import Control.Monad.State.Trans
 import Data.Monoid
 import Data.Tuple
 
-import qualified Control.Monad.RWS as RWS
-
 -- | The `MonadWriter w` type class represents those monads which support a monoidal accumulator
 -- | of type `w`.
 -- |
@@ -85,6 +83,6 @@ instance monadWriterReaderT :: (Monad m, MonadWriter w m) => MonadWriter w (Read
   pass = mapReaderT pass
 
 instance monadWriterRWST :: (Monad m, Monoid w) => MonadWriter w (RWST r w s m) where
-  writer = RWS.writer
-  listen = RWS.listen
-  pass = RWS.pass
+  writer (Tuple a w) = RWST \_ s -> pure $ {state: s, result: a, log: w}
+  listen m = RWST \r s -> runRWST m r s >>= \{state = s', result = a, log = w} -> pure $ {state: s', result: Tuple a w, log: w}
+  pass m = RWST \r s -> runRWST m r s >>= \{result = Tuple a f, state = s', log = w} -> pure $ {state: s', result: a, log: f w}


### PR DESCRIPTION
Currently `Control.Monad.RWS` exports non-mtly versions of the RWS operations, but there's no reason it should do that, as you can use the operations from the classes like we do for all the other transformers.