### PR TITLE
fix link to examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Monad and comonad transformers based on [mtl](http://hackage.haskell.org/package/mtl).
 
-- [Examples](examples/)
+- [Examples](test/Example/)
 
 ## Documentation
 


### PR DESCRIPTION
Noticed the link was broken in commit ea5deb54fbad04d3fac5896ce2ebc05ef3abbf6a. This fixes it.