### PR TITLE
Fix warnings generated by purescript-0.8.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,12 +30,12 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-distributive": "^0.5.0",
+    "purescript-distributive": "^1.0.0-rc.1",
     "purescript-lazy": "^0.4.0",
-    "purescript-tailrec": "^0.3.0",
-    "purescript-unfoldable": "^0.4.0"
+    "purescript-tailrec": "^1.0.0-rc.1",
+    "purescript-unfoldable": "^1.0.0-rc.1"
   },
   "devDependencies": {
-    "purescript-console": "^0.1.0"
+    "purescript-console": "^1.0.0-rc.1"
   }
 }

--- a/src/Control/Comonad/Env.purs
+++ b/src/Control/Comonad/Env.purs
@@ -2,9 +2,9 @@
 
 module Control.Comonad.Env where
 
-import Prelude
+import Prelude (($), map, (<$>))
 
-import Control.Comonad.Env.Trans
+import Control.Comonad.Env.Trans (EnvT(EnvT), withEnvT, runEnvT)
 
 import Data.Identity (Identity(..), runIdentity)
 import Data.Tuple (Tuple(..))

--- a/src/Control/Comonad/Env/Class.purs
+++ b/src/Control/Comonad/Env/Class.purs
@@ -2,10 +2,10 @@
 
 module Control.Comonad.Env.Class where
 
-import Prelude
+import Prelude (($))
 
-import Control.Comonad (Comonad)
-import Control.Comonad.Env.Trans
+import Control.Comonad (class Comonad)
+import Control.Comonad.Env.Trans (EnvT(EnvT), runEnvT)
 
 import Data.Tuple (Tuple(..), fst)
 

--- a/src/Control/Comonad/Env/Trans.purs
+++ b/src/Control/Comonad/Env/Trans.purs
@@ -2,11 +2,11 @@
 
 module Control.Comonad.Env.Trans where
 
-import Prelude
+import Prelude (class Functor, (>>>), (<$>), ($))
 
-import Control.Comonad (Comonad, extract)
-import Control.Comonad.Trans
-import Control.Extend (Extend, (<<=))
+import Control.Comonad (class Comonad, extract)
+import Control.Comonad.Trans (class ComonadTrans)
+import Control.Extend (class Extend, (<<=))
 
 import Data.Tuple (Tuple(..))
 

--- a/src/Control/Comonad/Store.purs
+++ b/src/Control/Comonad/Store.purs
@@ -2,9 +2,9 @@
 
 module Control.Comonad.Store where
 
-import Prelude
+import Prelude (($), (<$>))
 
-import Control.Comonad.Store.Trans
+import Control.Comonad.Store.Trans (StoreT(StoreT), runStoreT)
 
 import Data.Identity (Identity(..), runIdentity)
 import Data.Tuple (Tuple(..), swap)

--- a/src/Control/Comonad/Store/Class.purs
+++ b/src/Control/Comonad/Store/Class.purs
@@ -2,11 +2,11 @@
 
 module Control.Comonad.Store.Class where
 
-import Prelude
+import Prelude (class Functor, ($), flip, (<$>))
 
-import Control.Comonad (Comonad, extract)
-import Control.Comonad.Store.Trans
-import Control.Extend (Extend, duplicate)
+import Control.Comonad (class Comonad, extract)
+import Control.Comonad.Store.Trans (StoreT(StoreT))
+import Control.Extend (class Extend, duplicate)
 
 import Data.Tuple (Tuple(..))
 

--- a/src/Control/Comonad/Store/Trans.purs
+++ b/src/Control/Comonad/Store/Trans.purs
@@ -2,11 +2,11 @@
 
 module Control.Comonad.Store.Trans where
 
-import Prelude
+import Prelude (class Functor, (<$>), ($), (>>>))
 
-import Control.Comonad (Comonad, extract)
-import Control.Comonad.Trans
-import Control.Extend (Extend, (<<=))
+import Control.Comonad (class Comonad, extract)
+import Control.Comonad.Trans (class ComonadTrans)
+import Control.Extend (class Extend, (<<=))
 
 import Data.Tuple (Tuple(..))
 

--- a/src/Control/Comonad/Traced.purs
+++ b/src/Control/Comonad/Traced.purs
@@ -2,9 +2,9 @@
 
 module Control.Comonad.Traced where
 
-import Prelude
+import Prelude ((>>>))
 
-import Control.Comonad.Traced.Trans
+import Control.Comonad.Traced.Trans (TracedT(TracedT), runTracedT)
 
 import Data.Identity (Identity(..), runIdentity)
 

--- a/src/Control/Comonad/Traced/Class.purs
+++ b/src/Control/Comonad/Traced/Class.purs
@@ -2,12 +2,12 @@
 
 module Control.Comonad.Traced.Class where
 
-import Prelude
+import Prelude (class Functor, (>>>), (<$>), ($))
 
-import Control.Comonad (Comonad, extract)
-import Control.Comonad.Traced.Trans
+import Control.Comonad (class Comonad, extract)
+import Control.Comonad.Traced.Trans (TracedT(TracedT), runTracedT)
 
-import Data.Monoid (Monoid)
+import Data.Monoid (class Monoid)
 import Data.Tuple (Tuple(..))
 
 -- | The `ComonadTraced` type class represents those monads which support relative (monoidal)

--- a/src/Control/Comonad/Traced/Trans.purs
+++ b/src/Control/Comonad/Traced/Trans.purs
@@ -2,13 +2,13 @@
 
 module Control.Comonad.Traced.Trans where
 
-import Prelude
+import Prelude (class Semigroup, class Functor, (<$>), ($), (<>))
 
-import Control.Comonad (Comonad, extract)
-import Control.Comonad.Trans
-import Control.Extend (Extend, (<<=))
+import Control.Comonad (class Comonad, extract)
+import Control.Comonad.Trans (class ComonadTrans)
+import Control.Extend (class Extend, (<<=))
 
-import Data.Monoid (Monoid, mempty)
+import Data.Monoid (class Monoid, mempty)
 
 -- | The cowriter comonad transformer.
 -- |

--- a/src/Control/Comonad/Trans.purs
+++ b/src/Control/Comonad/Trans.purs
@@ -2,9 +2,7 @@
 
 module Control.Comonad.Trans where
 
-import Prelude
-
-import Control.Comonad (Comonad)
+import Control.Comonad (class Comonad)
 
 -- | The `ComonadTrans` type class represents _comonad transformers_.
 -- |

--- a/src/Control/Monad/Cont/Class.purs
+++ b/src/Control/Monad/Cont/Class.purs
@@ -1,11 +1,11 @@
 -- | This module defines the `MonadCont` type class and its instances.
 
-module Control.Monad.Cont.Class 
-  ( MonadCont
+module Control.Monad.Cont.Class
+  ( class MonadCont
   , callCC
   ) where
 
-import Prelude
+import Prelude (class Monad)
 
 -- | The `MonadCont` type class represents those monads which support the
 -- | `callCC`, or _call-with-current-continuation_ operation.

--- a/src/Control/Monad/Cont/Trans.purs
+++ b/src/Control/Monad/Cont/Trans.purs
@@ -1,18 +1,18 @@
 -- | This module defines the CPS monad transformer.
 
-module Control.Monad.Cont.Trans 
+module Control.Monad.Cont.Trans
   ( ContT(..), runContT, mapContT, withContT
   , module Control.Monad.Trans
   , module Control.Monad.Cont.Class
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
-import Control.Monad.Trans
-import Control.Monad.Eff.Class
-import Control.Monad.Cont.Class
-import Control.Monad.Reader.Class
-import Control.Monad.State.Class
+import Control.Monad.Trans (class MonadTrans, lift)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Monad.Cont.Class (class MonadCont, callCC)
+import Control.Monad.Reader.Class (class MonadReader, ask, local, reader)
+import Control.Monad.State.Class (class MonadState, get, gets, modify, put, state)
 
 -- | The CPS monad transformer.
 -- |
@@ -53,12 +53,12 @@ instance monadTransContT :: MonadTrans (ContT r) where
 
 instance monadEffContT :: (MonadEff eff m) => MonadEff eff (ContT r m) where
   liftEff = lift <<< liftEff
-  
+
 instance monadReaderContT :: (MonadReader r1 m) => MonadReader r1 (ContT r m) where
   ask = lift ask
   local f c = ContT \k -> do
     r <- ask
     local f (runContT c (local (const (r :: r1)) <<< k))
-    
+
 instance monadStateContT :: (MonadState s m) => MonadState s (ContT r m) where
   state = lift <<< state

--- a/src/Control/Monad/Cont/Trans.purs
+++ b/src/Control/Monad/Cont/Trans.purs
@@ -6,7 +6,7 @@ module Control.Monad.Cont.Trans
   , module Control.Monad.Cont.Class
   ) where
 
-import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
+import Prelude
 
 import Control.Monad.Trans (class MonadTrans, lift)
 import Control.Monad.Eff.Class (class MonadEff, liftEff)

--- a/src/Control/Monad/Error/Class.purs
+++ b/src/Control/Monad/Error/Class.purs
@@ -2,7 +2,7 @@
 
 module Control.Monad.Error.Class where
 
-import Prelude
+import Prelude (class Monad, Unit, unit, const)
 
 import Data.Maybe (Maybe(..))
 import Data.Either (Either(..))

--- a/src/Control/Monad/Except.purs
+++ b/src/Control/Monad/Except.purs
@@ -8,10 +8,10 @@ module Control.Monad.Except
   , module Control.Monad.Error.Class
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
-import Control.Monad.Error.Class
-import Control.Monad.Except.Trans
+import Control.Monad.Error.Class (catchJust)
+import Control.Monad.Except.Trans (class MonadError, class MonadTrans, ExceptT(ExceptT), catchError, lift, mapExceptT, runExceptT, throwError, withExceptT)
 
 import Data.Either (Either(..))
 import Data.Identity (Identity(..), runIdentity)
@@ -48,4 +48,3 @@ mapExcept f = mapExceptT (Identity <<< f <<< runIdentity)
 -- | Transform any exceptions thrown by an `Except` computation using the given function.
 withExcept :: forall e e' a. (e -> e') -> Except e a -> Except e' a
 withExcept = withExceptT
-

--- a/src/Control/Monad/Except.purs
+++ b/src/Control/Monad/Except.purs
@@ -8,7 +8,7 @@ module Control.Monad.Except
   , module Control.Monad.Error.Class
   ) where
 
-import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
+import Prelude
 
 import Control.Monad.Error.Class (catchJust)
 import Control.Monad.Except.Trans (class MonadError, class MonadTrans, ExceptT(ExceptT), catchError, lift, mapExceptT, runExceptT, throwError, withExceptT)

--- a/src/Control/Monad/Except/Trans.purs
+++ b/src/Control/Monad/Except/Trans.purs
@@ -6,21 +6,21 @@ module Control.Monad.Except.Trans
   , module Control.Monad.Error.Class
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
-import Control.Alt (Alt)
-import Control.Alternative (Alternative)
-import Control.Monad.Cont.Class (MonadCont, callCC)
-import Control.Monad.Eff.Class (MonadEff, liftEff)
-import Control.Monad.Error.Class (MonadError, throwError, catchError)
-import Control.Monad.Rec.Class (MonadRec, tailRecM)
-import Control.Monad.RWS.Class
-import Control.Monad.Trans
-import Control.MonadPlus (MonadPlus)
-import Control.Plus (Plus)
+import Control.Alt (class Alt)
+import Control.Alternative (class Alternative)
+import Control.Monad.Cont.Class (class MonadCont, callCC)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Monad.Error.Class (class MonadError, throwError, catchError)
+import Control.Monad.Rec.Class (class MonadRec, tailRecM)
+import Control.Monad.RWS.Class (class MonadRWS, class MonadReader, class MonadState, class MonadWriter, ask, censor, get, gets, listen, listens, local, modify, pass, put, reader, state, tell, writer)
+import Control.Monad.Trans (class MonadTrans, lift)
+import Control.MonadPlus (class MonadPlus)
+import Control.Plus (class Plus)
 
 import Data.Either (Either(..), either)
-import Data.Monoid (Monoid, mempty)
+import Data.Monoid (class Monoid, mempty)
 import Data.Tuple (Tuple(..))
 
 -- | A monad transformer which adds exceptions to other monads, in the same way

--- a/src/Control/Monad/List/Trans.purs
+++ b/src/Control/Monad/List/Trans.purs
@@ -31,20 +31,20 @@ module Control.Monad.List.Trans
   , module Control.Monad.Trans
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
-import Control.Alt (Alt)
-import Control.Alternative (Alternative)
-import Control.Monad.Eff.Class (MonadEff, liftEff)
-import Control.Monad.Trans (MonadTrans, lift)
-import Control.MonadPlus (MonadPlus)
-import Control.Plus (Plus)
+import Control.Alt (class Alt)
+import Control.Alternative (class Alternative)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Monad.Trans (class MonadTrans, lift)
+import Control.MonadPlus (class MonadPlus)
+import Control.Plus (class Plus)
 
 import Data.Lazy (Lazy(), defer, force)
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Monoid (Monoid)
+import Data.Monoid (class Monoid)
 import Data.Tuple (Tuple(..), fst, snd)
-import Data.Unfoldable (Unfoldable)
+import Data.Unfoldable (class Unfoldable)
 
 -- | The list monad transformer.
 -- |

--- a/src/Control/Monad/Maybe/Trans.purs
+++ b/src/Control/Monad/Maybe/Trans.purs
@@ -5,23 +5,23 @@ module Control.Monad.Maybe.Trans
   , module Control.Monad.Trans
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
-import Data.Monoid (Monoid)
+import Data.Monoid (class Monoid)
 
-import Control.Alt (Alt)
-import Control.Alternative (Alternative)
-import Control.Monad.Trans
-import Control.Monad.Rec.Class
-import Control.Monad.Eff.Class
-import Control.Monad.Cont.Class
-import Control.Monad.Error.Class
-import Control.Monad.RWS.Class
-import Control.MonadPlus (MonadPlus)
-import Control.Plus (Plus)
+import Control.Alt (class Alt)
+import Control.Alternative (class Alternative)
+import Control.Monad.Trans (class MonadTrans, lift)
+import Control.Monad.Rec.Class (class MonadRec, forever, tailRec, tailRecM, tailRecM2, tailRecM3)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Monad.Cont.Class (class MonadCont, callCC)
+import Control.Monad.Error.Class (class MonadError, catchError, catchJust, throwError)
+import Control.Monad.RWS.Class (class MonadRWS, class MonadReader, class MonadState, class MonadWriter, ask, censor, get, gets, listen, listens, local, modify, pass, put, reader, state, tell, writer)
+import Control.MonadPlus (class MonadPlus)
+import Control.Plus (class Plus)
 
 -- | The `MaybeT` monad transformer.
 -- |

--- a/src/Control/Monad/Maybe/Trans.purs
+++ b/src/Control/Monad/Maybe/Trans.purs
@@ -5,7 +5,7 @@ module Control.Monad.Maybe.Trans
   , module Control.Monad.Trans
   ) where
 
-import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
+import Prelude
 
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
@@ -21,6 +21,7 @@ import Control.Monad.Cont.Class (class MonadCont, callCC)
 import Control.Monad.Error.Class (class MonadError, catchError, catchJust, throwError)
 import Control.Monad.RWS.Class (class MonadRWS, class MonadReader, class MonadState, class MonadWriter, ask, censor, get, gets, listen, listens, local, modify, pass, put, reader, state, tell, writer)
 import Control.MonadPlus (class MonadPlus)
+import Control.MonadZero (class MonadZero)
 import Control.Plus (class Plus)
 
 -- | The `MaybeT` monad transformer.
@@ -50,7 +51,7 @@ instance bindMaybeT :: (Monad m) => Bind (MaybeT m) where
   bind x f = MaybeT $ do
     v <- runMaybeT x
     case v of
-      Nothing -> return Nothing
+      Nothing -> pure Nothing
       Just y  -> runMaybeT (f y)
 
 instance monadMaybeT :: (Monad m) => Monad (MaybeT m)
@@ -63,7 +64,7 @@ instance altMaybeT :: (Monad m) => Alt (MaybeT m) where
     m <- runMaybeT m1
     case m of
       Nothing -> runMaybeT m2
-      ja -> return ja
+      ja -> pure ja
 
 instance plusMaybeT :: (Monad m) => Plus (MaybeT m) where
   empty = MaybeT (pure Nothing)
@@ -72,10 +73,12 @@ instance alternativeMaybeT :: (Monad m) => Alternative (MaybeT m)
 
 instance monadPlusMaybeT :: (Monad m) => MonadPlus (MaybeT m)
 
+instance monadZeroMaybeT :: (Monad m) => MonadZero (MaybeT m)
+
 instance monadRecMaybeT :: (MonadRec m) => MonadRec (MaybeT m) where
   tailRecM f = MaybeT <<< tailRecM \a -> do
     m <- runMaybeT (f a)
-    return case m of
+    pure case m of
       Nothing -> Right Nothing
       Just (Left a1) -> Left a1
       Just (Right b) -> Right (Just b)
@@ -101,10 +104,10 @@ instance monadWriterMaybeT :: (Monad m, MonadWriter w m) => MonadWriter w (Maybe
   writer wd = lift (writer wd)
   listen = mapMaybeT $ \m -> do
     Tuple a w <- listen m
-    return $ (\r -> Tuple r w) <$> a
+    pure $ (\r -> Tuple r w) <$> a
   pass = mapMaybeT $ \m -> pass $ do
     a <- m
-    return $ case a of
+    pure $ case a of
       Nothing -> Tuple Nothing id
       Just (Tuple v f) -> Tuple (Just v) f
 

--- a/src/Control/Monad/RWS.purs
+++ b/src/Control/Monad/RWS.purs
@@ -8,12 +8,12 @@ module Control.Monad.RWS
   , execRWS
   , mapRWS
   , withRWS
-  , module Control.Monad.RWS.Class
+  , module X
   ) where
 
-import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
+import Prelude
 
-import Control.Monad.RWS.Class
+import Control.Monad.RWS.Class as X
 import Control.Monad.RWS.Trans (class MonadRWS, class MonadReader, class MonadState, class MonadTrans, class MonadWriter, RWSResult(RWSResult), RWST(RWST), ask, censor, evalRWST, execRWST, get, gets, lift, listen, listens, local, mapRWST, modify, pass, put, reader, runRWST, state, tell, withRWST, writer)
 
 import Data.Identity (Identity(..), runIdentity)
@@ -26,7 +26,7 @@ type RWS r w s = RWST r w s Identity
 -- | Create an action in the `RWS` monad from a function which uses the
 -- | global context and state explicitly.
 rws :: forall r w s a. (r -> s -> RWSResult s a w) -> RWS r w s a
-rws f = RWST \r s -> return $ f r s
+rws f = RWST \r s -> pure $ f r s
 
 -- | Run a computation in the `RWS` monad.
 runRWS :: forall r w s a. RWS r w s a -> r -> s -> RWSResult s a w

--- a/src/Control/Monad/RWS.purs
+++ b/src/Control/Monad/RWS.purs
@@ -11,10 +11,10 @@ module Control.Monad.RWS
   , module Control.Monad.RWS.Class
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
 import Control.Monad.RWS.Class
-import Control.Monad.RWS.Trans
+import Control.Monad.RWS.Trans (class MonadRWS, class MonadReader, class MonadState, class MonadTrans, class MonadWriter, RWSResult(RWSResult), RWST(RWST), ask, censor, evalRWST, execRWST, get, gets, lift, listen, listens, local, mapRWST, modify, pass, put, reader, runRWST, state, tell, withRWST, writer)
 
 import Data.Identity (Identity(..), runIdentity)
 import Data.Tuple (Tuple())

--- a/src/Control/Monad/RWS/Class.purs
+++ b/src/Control/Monad/RWS/Class.purs
@@ -1,21 +1,21 @@
 -- | This module defines the `MonadRWS` type class and its instances.
 
 module Control.Monad.RWS.Class
-  ( MonadRWS
+  ( class MonadRWS
   , module Control.Monad.Trans
   , module Control.Monad.Reader.Class
   , module Control.Monad.Writer.Class
   , module Control.Monad.State.Class
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
-import Control.Monad.Reader.Class
-import Control.Monad.State.Class
-import Control.Monad.Trans
-import Control.Monad.Writer.Class
+import Control.Monad.Reader.Class (class MonadReader, ask, local, reader)
+import Control.Monad.State.Class (class MonadState, get, gets, modify, put, state)
+import Control.Monad.Trans (class MonadTrans, lift)
+import Control.Monad.Writer.Class (class MonadWriter, censor, listen, listens, pass, tell, writer)
 
-import Data.Monoid (Monoid)
+import Data.Monoid (class Monoid)
 
 -- | `MonadRWS r w s` combines the operations and laws of the `MonadReader r`,
 -- | `MonadWriter w` and `MonadState s` type classes.

--- a/src/Control/Monad/RWS/Class.purs
+++ b/src/Control/Monad/RWS/Class.purs
@@ -8,7 +8,7 @@ module Control.Monad.RWS.Class
   , module Control.Monad.State.Class
   ) where
 
-import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
+import Prelude
 
 import Control.Monad.Reader.Class (class MonadReader, ask, local, reader)
 import Control.Monad.State.Class (class MonadState, get, gets, modify, put, state)

--- a/src/Control/Monad/RWS/Trans.purs
+++ b/src/Control/Monad/RWS/Trans.purs
@@ -7,16 +7,16 @@ module Control.Monad.RWS.Trans
   , module Control.Monad.RWS.Class
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
-import Control.Monad.Eff.Class
-import Control.Monad.Error.Class
-import Control.Monad.Rec.Class
-import Control.Monad.RWS.Class
-import Control.Monad.Trans
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Monad.Error.Class (class MonadError, catchError, catchJust, throwError)
+import Control.Monad.Rec.Class (class MonadRec, forever, tailRec, tailRecM, tailRecM2, tailRecM3)
+import Control.Monad.RWS.Class (class MonadRWS, class MonadReader, class MonadState, class MonadWriter, ask, censor, get, gets, listen, listens, local, modify, pass, put, reader, state, tell, writer)
+import Control.Monad.Trans (class MonadTrans, lift)
 
 import Data.Either (Either(..))
-import Data.Monoid (Monoid, mempty)
+import Data.Monoid (class Monoid, mempty)
 import Data.Tuple (Tuple(..), uncurry)
 
 data RWSResult state result writer = RWSResult state result writer

--- a/src/Control/Monad/Reader.purs
+++ b/src/Control/Monad/Reader.purs
@@ -5,12 +5,12 @@ module Control.Monad.Reader
   , runReader
   , mapReader
   , withReader
-  , module Control.Monad.Reader.Class
+  , module X
   ) where
 
-import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
+import Prelude
 
-import Control.Monad.Reader.Class
+import Control.Monad.Reader.Class (reader) as X
 import Control.Monad.Reader.Trans (class MonadReader, class MonadTrans, ReaderT(ReaderT), ask, lift, local, mapReaderT, reader, runReaderT, withReaderT)
 
 import Data.Identity (Identity(..), runIdentity)

--- a/src/Control/Monad/Reader.purs
+++ b/src/Control/Monad/Reader.purs
@@ -8,10 +8,10 @@ module Control.Monad.Reader
   , module Control.Monad.Reader.Class
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
 import Control.Monad.Reader.Class
-import Control.Monad.Reader.Trans
+import Control.Monad.Reader.Trans (class MonadReader, class MonadTrans, ReaderT(ReaderT), ask, lift, local, mapReaderT, reader, runReaderT, withReaderT)
 
 import Data.Identity (Identity(..), runIdentity)
 

--- a/src/Control/Monad/Reader/Class.purs
+++ b/src/Control/Monad/Reader/Class.purs
@@ -2,7 +2,7 @@
 
 module Control.Monad.Reader.Class where
 
-import Prelude (class Monad, (>>>), id, return, (<<<), (>>=))
+import Prelude (class Monad, (>>>), id, pure, (<<<), (>>=))
 
 -- | The `MonadReader` type class represents those monads which support a global context via
 -- | `ask` and `local`.
@@ -25,7 +25,7 @@ class (Monad m) <= MonadReader r m where
 
 -- | Read a value which depends on the global context in any `MonadReader`.
 reader :: forall r m a. (MonadReader r m) => (r -> a) -> m a
-reader f = ask >>= return <<< f
+reader f = ask >>= pure <<< f
 
 instance monadReaderFun :: MonadReader r ((->) r) where
   ask = id

--- a/src/Control/Monad/Reader/Class.purs
+++ b/src/Control/Monad/Reader/Class.purs
@@ -2,7 +2,7 @@
 
 module Control.Monad.Reader.Class where
 
-import Prelude
+import Prelude (class Monad, (>>>), id, return, (<<<), (>>=))
 
 -- | The `MonadReader` type class represents those monads which support a global context via
 -- | `ask` and `local`.

--- a/src/Control/Monad/Reader/Trans.purs
+++ b/src/Control/Monad/Reader/Trans.purs
@@ -6,7 +6,7 @@ module Control.Monad.Reader.Trans
   , module Control.Monad.Reader.Class
   ) where
 
-import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
+import Prelude
 
 import Control.Alt (class Alt, (<|>))
 import Control.Alternative (class Alternative)
@@ -19,6 +19,7 @@ import Control.Monad.State.Class (class MonadState, get, gets, modify, put, stat
 import Control.Monad.Trans (class MonadTrans, lift)
 import Control.Monad.Writer.Class (class MonadWriter, censor, listen, listens, pass, tell, writer)
 import Control.MonadPlus (class MonadPlus)
+import Control.MonadZero (class MonadZero)
 import Control.Plus (class Plus, empty)
 
 import Data.Distributive (class Distributive, distribute, collect)
@@ -70,6 +71,8 @@ instance monadReaderT :: (Monad m) => Monad (ReaderT r m)
 
 instance monadPlusReaderT :: (MonadPlus m) => MonadPlus (ReaderT r m)
 
+instance monadZeroReaderT :: (MonadZero m) => MonadZero (ReaderT r m)
+
 instance monadTransReaderT :: MonadTrans (ReaderT r) where
   lift = ReaderT <<< const
 
@@ -84,7 +87,7 @@ instance monadErrorReaderT :: (MonadError e m) => MonadError e (ReaderT r m) whe
   catchError m h = ReaderT $ \r -> catchError (runReaderT m r) (\e -> runReaderT (h e) r)
 
 instance monadReaderReaderT :: (Monad m) => MonadReader r (ReaderT r m) where
-  ask = ReaderT return
+  ask = ReaderT pure
   local = withReaderT
 
 instance monadStateReaderT :: (MonadState s m) => MonadState s (ReaderT r m) where
@@ -104,4 +107,4 @@ instance monadRecReaderT :: (MonadRec m) => MonadRec (ReaderT r m) where
     where
     k' r a = do
       result <- runReaderT (k a) r
-      return $ either Left Right result
+      pure $ either Left Right result

--- a/src/Control/Monad/Reader/Trans.purs
+++ b/src/Control/Monad/Reader/Trans.purs
@@ -6,22 +6,22 @@ module Control.Monad.Reader.Trans
   , module Control.Monad.Reader.Class
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
-import Control.Alt (Alt, (<|>))
-import Control.Alternative (Alternative)
-import Control.Monad.Cont.Class
-import Control.Monad.Eff.Class
-import Control.Monad.Error.Class
-import Control.Monad.Reader.Class
-import Control.Monad.Rec.Class
-import Control.Monad.State.Class
-import Control.Monad.Trans
-import Control.Monad.Writer.Class
-import Control.MonadPlus (MonadPlus)
-import Control.Plus (Plus, empty)
+import Control.Alt (class Alt, (<|>))
+import Control.Alternative (class Alternative)
+import Control.Monad.Cont.Class (class MonadCont, callCC)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Monad.Error.Class (class MonadError, catchError, catchJust, throwError)
+import Control.Monad.Reader.Class (class MonadReader, ask, local, reader)
+import Control.Monad.Rec.Class (class MonadRec, forever, tailRec, tailRecM, tailRecM2, tailRecM3)
+import Control.Monad.State.Class (class MonadState, get, gets, modify, put, state)
+import Control.Monad.Trans (class MonadTrans, lift)
+import Control.Monad.Writer.Class (class MonadWriter, censor, listen, listens, pass, tell, writer)
+import Control.MonadPlus (class MonadPlus)
+import Control.Plus (class Plus, empty)
 
-import Data.Distributive (Distributive, distribute, collect)
+import Data.Distributive (class Distributive, distribute, collect)
 import Data.Either (Either(..), either)
 
 -- | The reader monad transformer.

--- a/src/Control/Monad/State.purs
+++ b/src/Control/Monad/State.purs
@@ -10,10 +10,10 @@ module Control.Monad.State
   , module Control.Monad.State.Class
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
 import Control.Monad.State.Class
-import Control.Monad.State.Trans
+import Control.Monad.State.Trans (class MonadState, class MonadTrans, StateT(StateT), evalStateT, execStateT, get, gets, lift, mapStateT, modify, put, runStateT, state, withStateT)
 
 import Data.Identity (Identity(..), runIdentity)
 import Data.Tuple (Tuple(), fst, snd)

--- a/src/Control/Monad/State.purs
+++ b/src/Control/Monad/State.purs
@@ -7,12 +7,12 @@ module Control.Monad.State
   , execState
   , mapState
   , withState
-  , module Control.Monad.State.Class
+  , module X
   ) where
 
-import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
+import Prelude
 
-import Control.Monad.State.Class
+import Control.Monad.State.Class (get, gets, put, modify) as X
 import Control.Monad.State.Trans (class MonadState, class MonadTrans, StateT(StateT), evalStateT, execStateT, get, gets, lift, mapStateT, modify, put, runStateT, state, withStateT)
 
 import Data.Identity (Identity(..), runIdentity)

--- a/src/Control/Monad/State/Class.purs
+++ b/src/Control/Monad/State/Class.purs
@@ -2,9 +2,8 @@
 
 module Control.Monad.State.Class where
 
-import Prelude
+import Prelude (class Monad, Unit, unit)
 
-import Data.Monoid (Monoid)
 import Data.Tuple (Tuple(..))
 
 -- | The `MonadState s` type class represents those monads which support a single piece of mutable

--- a/src/Control/Monad/State/Trans.purs
+++ b/src/Control/Monad/State/Trans.purs
@@ -6,21 +6,21 @@ module Control.Monad.State.Trans
   , module Control.Monad.State.Class
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
-import Control.Alt (Alt, (<|>))
-import Control.Alternative (Alternative)
-import Control.Lazy (Lazy)
-import Control.Monad.Cont.Class
-import Control.Monad.Eff.Class
-import Control.Monad.Error.Class
-import Control.Monad.Reader.Class
-import Control.Monad.Rec.Class
-import Control.Monad.State.Class
-import Control.Monad.Trans
-import Control.Monad.Writer.Class
-import Control.MonadPlus (MonadPlus)
-import Control.Plus (Plus, empty)
+import Control.Alt (class Alt, (<|>))
+import Control.Alternative (class Alternative)
+import Control.Lazy (class Lazy)
+import Control.Monad.Cont.Class (class MonadCont, callCC)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Monad.Error.Class (class MonadError, catchError, catchJust, throwError)
+import Control.Monad.Reader.Class (class MonadReader, ask, local, reader)
+import Control.Monad.Rec.Class (class MonadRec, forever, tailRec, tailRecM, tailRecM2, tailRecM3)
+import Control.Monad.State.Class (class MonadState, get, gets, modify, put, state)
+import Control.Monad.Trans (class MonadTrans, lift)
+import Control.Monad.Writer.Class (class MonadWriter, censor, listen, listens, pass, tell, writer)
+import Control.MonadPlus (class MonadPlus)
+import Control.Plus (class Plus, empty)
 
 import Data.Either (Either(..))
 import Data.Tuple (Tuple(..), fst, snd)

--- a/src/Control/Monad/Trans.purs
+++ b/src/Control/Monad/Trans.purs
@@ -2,7 +2,7 @@
 
 module Control.Monad.Trans where
 
-import Prelude
+import Prelude (class Monad)
 
 -- | The `MonadTrans` type class represents _monad transformers_.
 -- |
@@ -12,7 +12,7 @@ import Prelude
 -- | This allows us to add additional effects to an existing monad. By iterating this
 -- | process, we create monad transformer _stacks_, which contain all of the effects
 -- | required for a particular computation.
--- | 
+-- |
 -- | The laws state that `lift` is a `Monad` morphism.
 -- |
 -- | Laws:

--- a/src/Control/Monad/Writer.purs
+++ b/src/Control/Monad/Writer.purs
@@ -8,10 +8,10 @@ module Control.Monad.Writer
   , module Control.Monad.Writer.Class
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
 import Control.Monad.Writer.Class
-import Control.Monad.Writer.Trans
+import Control.Monad.Writer.Trans (class MonadTrans, class MonadWriter, WriterT(WriterT), censor, execWriterT, lift, listen, listens, mapWriterT, pass, runWriterT, tell, writer)
 
 import Data.Identity (Identity(..), runIdentity)
 import Data.Tuple (Tuple(), snd)

--- a/src/Control/Monad/Writer.purs
+++ b/src/Control/Monad/Writer.purs
@@ -5,12 +5,12 @@ module Control.Monad.Writer
   , runWriter
   , execWriter
   , mapWriter
-  , module Control.Monad.Writer.Class
+  , module X
   ) where
 
-import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
+import Prelude
 
-import Control.Monad.Writer.Class
+import Control.Monad.Writer.Class (tell, listens, censor) as X
 import Control.Monad.Writer.Trans (class MonadTrans, class MonadWriter, WriterT(WriterT), censor, execWriterT, lift, listen, listens, mapWriterT, pass, runWriterT, tell, writer)
 
 import Data.Identity (Identity(..), runIdentity)

--- a/src/Control/Monad/Writer/Class.purs
+++ b/src/Control/Monad/Writer/Class.purs
@@ -2,7 +2,7 @@
 
 module Control.Monad.Writer.Class where
 
-import Prelude (class Monad, Unit, return, ($), bind, unit)
+import Prelude (class Monad, Unit, pure, ($), bind, unit)
 
 import Data.Monoid (class Monoid)
 import Data.Tuple (Tuple(..))
@@ -37,10 +37,10 @@ tell w = writer $ Tuple unit w
 listens :: forall w m a b. (Monoid w, Monad m, MonadWriter w m) => (w -> b) -> m a -> m (Tuple a b)
 listens f m = do
   Tuple a w <- listen m
-  return $ Tuple a (f w)
+  pure $ Tuple a (f w)
 
 -- | Modify the final accumulator value by applying a function.
 censor :: forall w m a. (Monoid w, Monad m, MonadWriter w m) => (w -> w) -> m a -> m a
 censor f m = pass $ do
   a <- m
-  return $ Tuple a f
+  pure $ Tuple a f

--- a/src/Control/Monad/Writer/Class.purs
+++ b/src/Control/Monad/Writer/Class.purs
@@ -2,9 +2,9 @@
 
 module Control.Monad.Writer.Class where
 
-import Prelude
+import Prelude (class Monad, Unit, return, ($), bind, unit)
 
-import Data.Monoid (Monoid)
+import Data.Monoid (class Monoid)
 import Data.Tuple (Tuple(..))
 
 -- | The `MonadWriter w` type class represents those monads which support a monoidal accumulator

--- a/src/Control/Monad/Writer/Trans.purs
+++ b/src/Control/Monad/Writer/Trans.purs
@@ -6,24 +6,24 @@ module Control.Monad.Writer.Trans
   , module Control.Monad.Writer.Class
   ) where
 
-import Prelude
+import Prelude (class Applicative, class Apply, class Bind, class BooleanAlgebra, class Bounded, class BoundedOrd, class Category, class DivisionRing, class Eq, class Functor, class ModuloSemiring, class Monad, class Num, class Ord, class Ring, class Semigroup, class Semigroupoid, class Semiring, class Show, Unit, Ordering(EQ, GT, LT), add, ap, append, apply, asTypeOf, bind, bottom, compare, compose, conj, const, disj, div, eq, flip, id, liftA1, liftM1, map, mod, mul, negate, not, one, otherwise, pure, return, show, sub, top, unit, unsafeCompare, void, zero, (#), ($), (&&), (*), (+), (++), (-), (/), (/=), (<), (<#>), (<$>), (<*>), (<<<), (<=), (<>), (==), (>), (>=), (>>=), (>>>), (||))
 
 import Data.Either (Either(..))
-import Data.Monoid (Monoid, mempty)
+import Data.Monoid (class Monoid, mempty)
 import Data.Tuple (Tuple(..), snd)
 
-import Control.Alt (Alt, (<|>))
-import Control.Alternative (Alternative)
-import Control.Monad.Cont.Class
-import Control.Monad.Eff.Class
-import Control.Monad.Error.Class
-import Control.Monad.Reader.Class
-import Control.Monad.Rec.Class
-import Control.Monad.State.Class
-import Control.Monad.Trans
-import Control.Monad.Writer.Class
-import Control.MonadPlus (MonadPlus)
-import Control.Plus (Plus, empty)
+import Control.Alt (class Alt, (<|>))
+import Control.Alternative (class Alternative)
+import Control.Monad.Cont.Class (class MonadCont, callCC)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Monad.Error.Class (class MonadError, catchError, catchJust, throwError)
+import Control.Monad.Reader.Class (class MonadReader, ask, local, reader)
+import Control.Monad.Rec.Class (class MonadRec, forever, tailRec, tailRecM, tailRecM2, tailRecM3)
+import Control.Monad.State.Class (class MonadState, get, gets, modify, put, state)
+import Control.Monad.Trans (class MonadTrans, lift)
+import Control.Monad.Writer.Class (class MonadWriter, censor, listen, listens, pass, tell, writer)
+import Control.MonadPlus (class MonadPlus)
+import Control.Plus (class Plus, empty)
 
 -- | The writer monad transformer.
 -- |


### PR DESCRIPTION
There are still a couple of warnings from where a module was imported and re-exported without actually being used locally. I didn't want to alter the semantics, so I left it alone. Plus after reading the discussions at purescript/purescript#1869 and purescript/purescript#1872 it seems like that issue is already known. @garyb I built off of your branch since this was just more import work. If I need to change anything let me know. :)