### PR TITLE
generalise Control.Monad.Except.except to ExceptT

### DIFF
--- a/src/Control/Monad/Except.purs
+++ b/src/Control/Monad/Except.purs
@@ -34,8 +34,8 @@ import Data.Identity (Identity(..), runIdentity)
 type Except e a = ExceptT e Identity a
 
 -- | Construct a computation in the `Except` monad from an `Either` value.
-except :: forall e a. Either e a -> Except e a
-except = ExceptT <<< Identity
+except :: forall e m a. (Applicative m) => Either e a -> ExceptT e m a
+except = ExceptT <<< return
 
 -- | Run a computation in the `Except` monad. The inverse of `except`.
 runExcept :: forall e a. Except e a -> Either e a

--- a/src/Control/Monad/Except.purs
+++ b/src/Control/Monad/Except.purs
@@ -1,17 +1,18 @@
 
 module Control.Monad.Except
   ( Except()
-  , except
   , runExcept
   , mapExcept
   , withExcept
   , module Control.Monad.Error.Class
+  , module Trans
   ) where
 
 import Prelude
 
 import Control.Monad.Error.Class
 import Control.Monad.Except.Trans (ExceptT(..), withExceptT, runExceptT, mapExceptT)
+import qualified Control.Monad.Except.Trans (except) as Trans
 
 import Data.Either (Either())
 import Data.Identity (Identity(..), runIdentity)
@@ -32,10 +33,6 @@ import Data.Identity (Identity(..), runIdentity)
 -- | exception; naturally, this requires the stronger constraint of a `Monoid`
 -- | instance for the exception type.
 type Except e a = ExceptT e Identity a
-
--- | Construct a computation in the `Except` monad from an `Either` value.
-except :: forall e m a. (Applicative m) => Either e a -> ExceptT e m a
-except = ExceptT <<< return
 
 -- | Run a computation in the `Except` monad. The inverse of `except`.
 runExcept :: forall e a. Except e a -> Either e a

--- a/src/Control/Monad/Except/Trans.purs
+++ b/src/Control/Monad/Except/Trans.purs
@@ -1,7 +1,7 @@
 -- | This module defines the _exception monad transformer_ `ExceptT`.
 
 module Control.Monad.Except.Trans
-  ( ExceptT(..), runExceptT, withExceptT, mapExceptT
+  ( ExceptT(..), runExceptT, withExceptT, mapExceptT, except
   , module Control.Monad.Trans
   , module Control.Monad.Error.Class
   ) where
@@ -46,6 +46,10 @@ withExceptT f = ExceptT <<< (<$>) (mapLeft f) <<< runExceptT
 -- | Transform the unwrapped computation using the given function.
 mapExceptT :: forall e e' m n a b. (m (Either e a) -> n (Either e' b)) -> ExceptT e m a -> ExceptT e' n b
 mapExceptT f m = ExceptT (f (runExceptT m))
+
+-- | Construct a computation in the `ExceptT` transformer from an `Either` value.
+except :: forall e m a. (Applicative m) => Either e a -> ExceptT e m a
+except = ExceptT <<< return
 
 instance functorExceptT :: (Functor m) => Functor (ExceptT e m) where
   map f = mapExceptT ((<$>) ((<$>) f))


### PR DESCRIPTION
I think this is reasonable, it's backwards compatible and may be useful for some. I'm frequently using ExceptT anyway.