### PR TITLE
fix runListT

### DIFF
--- a/src/Control/Monad/List/Trans.purs
+++ b/src/Control/Monad/List/Trans.purs
@@ -11,6 +11,7 @@ module Control.Monad.List.Trans
   , foldl
   , foldlRec
   , foldl'
+  , foldlRec'
   , fromEffect
   , head
   , iterate
@@ -204,6 +205,15 @@ foldl' f = loop where
     where
     g Nothing             = pure b
     g (Just (Tuple a as)) = (f b a) >>= (flip loop as)
+
+-- | Fold a list from the left, accumulating the result (effectfully) using the specified function.
+-- | Uses tail call optimization.
+foldlRec' :: forall f a b. MR.MonadRec f => (b -> a -> f b) -> b -> ListT f a -> f b
+foldlRec' f = MR.tailRecM2 loop where
+  loop b l = uncons l >>= g
+    where
+    g Nothing             = pure (MR.Done b)
+    g (Just (Tuple a as)) = (f b a) >>= \b' -> pure (MR.Loop {a: b', b: as})
 
 -- | Fold a list from the left, accumulating the result using the specified function.
 foldl :: forall f a b. Monad f => (b -> a -> b) -> b -> ListT f a -> f b

--- a/src/Control/Monad/List/Trans.purs
+++ b/src/Control/Monad/List/Trans.purs
@@ -21,6 +21,7 @@ module Control.Monad.List.Trans
   , prepend'
   , repeat
   , runListT
+  , runListTRec
   , scanl
   , singleton
   , tail
@@ -74,6 +75,11 @@ data Step a s
 -- | Drain a `ListT`, running it to completion and discarding all values.
 runListT :: forall f a. Monad f => ListT f a -> f Unit
 runListT = foldl' (\_ _ -> pure unit) unit
+
+-- | Drain a `ListT`, running it to completion and discarding all values.
+-- | Stack safe: Uses tail call optimization.
+runListTRec :: forall f a. MR.MonadRec f => ListT f a -> f Unit
+runListTRec = foldlRec' (\_ _ -> pure unit) unit
 
 -- | The empty list.
 nil :: forall f a. Applicative f => ListT f a

--- a/src/Control/Monad/List/Trans.purs
+++ b/src/Control/Monad/List/Trans.purs
@@ -9,6 +9,7 @@ module Control.Monad.List.Trans
   , dropWhile
   , filter
   , foldl
+  , foldlRec
   , foldl'
   , fromEffect
   , head
@@ -205,14 +206,22 @@ foldl' f = loop where
     g (Just (Tuple a as)) = (f b a) >>= (flip loop as)
 
 -- | Fold a list from the left, accumulating the result using the specified function.
-foldl :: forall f a b. MR.MonadRec f => (b -> a -> b) -> b -> ListT f a -> f b
-foldl f b l = (MR.tailRecM2 loop) b l
+foldl :: forall f a b. Monad f => (b -> a -> b) -> b -> ListT f a -> f b
+foldl f = loop where
+  loop b l = uncons l >>= g
+    where
+    g Nothing             = pure b
+    g (Just (Tuple a as)) = loop (f b a) as
+
+-- | Fold a list from the left, accumulating the result using the specified function.
+-- | Uses tail call optimization.
+foldlRec :: forall f a b. MR.MonadRec f => (b -> a -> b) -> b -> ListT f a -> f b
+foldlRec f = MR.tailRecM2 loop
   where
-    loop :: b -> ListT f a -> f (MR.Step {a :: b, b :: ListT f a}  b)
-    loop accum l' = uncons l' >>= g
+    loop b l = uncons l >>= g
       where
-      g Nothing             = pure (MR.Done accum)
-      g (Just (Tuple a as)) = pure (MR.Loop {a: f accum a, b: as})
+      g Nothing             = pure (MR.Done b)
+      g (Just (Tuple a as)) = pure (MR.Loop {a: f b a, b: as})
 
 -- | Fold a list from the left, accumulating the list of results using the specified function.
 scanl :: forall f a b. Monad f => (b -> a -> b) -> b -> ListT f a -> ListT f b

--- a/src/Control/Monad/List/Trans.purs
+++ b/src/Control/Monad/List/Trans.purs
@@ -20,6 +20,7 @@ module Control.Monad.List.Trans
   , prepend
   , prepend'
   , repeat
+  , runListT
   , scanl
   , singleton
   , tail
@@ -70,9 +71,9 @@ data Step a s
   | Skip (Lazy s)
   | Done
 
--- | Run a computation in the `ListT` monad.
-runListT :: forall f a. ListT f a -> f (Step a (ListT f a))
-runListT (ListT fa) = fa
+-- | Drain a `ListT`, running it to completion and discarding all values.
+runListT :: forall f a. Monad f => ListT f a -> f Unit
+runListT = foldl' (\_ action -> void (pure action)) unit
 
 -- | The empty list.
 nil :: forall f a. Applicative f => ListT f a

--- a/src/Control/Monad/List/Trans.purs
+++ b/src/Control/Monad/List/Trans.purs
@@ -73,7 +73,7 @@ data Step a s
 
 -- | Drain a `ListT`, running it to completion and discarding all values.
 runListT :: forall f a. Monad f => ListT f a -> f Unit
-runListT = foldl' (\_ action -> void (pure action)) unit
+runListT = foldl' (\_ _ -> pure unit) unit
 
 -- | The empty list.
 nil :: forall f a. Applicative f => ListT f a

--- a/test/Example/List.purs
+++ b/test/Example/List.purs
@@ -1,0 +1,38 @@
+module Example.List where
+
+import Prelude
+import Data.Array as A
+import Data.List.Lazy as L
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.Eff.Console (CONSOLE, log)
+import Control.Monad.List.Trans (ListT, runListT)
+import Control.MonadZero (guard)
+
+-- based on http://hackage.haskell.org/package/list-transformer
+logList :: forall eff.
+   ListT (Eff (console :: CONSOLE | eff)) String
+-> Eff (console :: CONSOLE | eff) Unit
+logList l = runListT do
+  liftEff $ log "logging listT"
+  str <- l
+  liftEff $ log str
+
+-- based on https://wiki.haskell.org/ListT_done_right#Sum_of_squares
+sumSqrs :: forall eff.
+   Int
+-> ListT (Eff (console :: CONSOLE | eff)) Unit
+sumSqrs n = do
+  let
+    nats = L.iterate (add one) zero -- lazy infinite list
+    squares = L.toUnfoldable <<< L.takeWhile (_ <= n) $ map (\x -> x * x) nats
+  x <- squares
+  y <- squares
+  liftEff $ log ("<" <> show x <> "," <> show y <> ">")
+  guard $ x + y == n
+  liftEff $ log "Sum of squares."
+
+main :: forall eff. Eff (console :: CONSOLE | eff) Unit
+main = do
+  logList $ A.toUnfoldable ["one", "two", "three"]
+  runListT $ sumSqrs 10

--- a/test/Example/List.purs
+++ b/test/Example/List.purs
@@ -2,18 +2,17 @@ module Example.List where
 
 import Prelude
 import Data.Array as A
-import Data.List.Lazy as L
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE, log)
-import Control.Monad.List.Trans (ListT, runListT)
+import Control.Monad.List.Trans (ListT, runListTRec, iterate, takeWhile)
 import Control.MonadZero (guard)
 
 -- based on http://hackage.haskell.org/package/list-transformer
 logList :: forall eff.
    ListT (Eff (console :: CONSOLE | eff)) String
 -> Eff (console :: CONSOLE | eff) Unit
-logList l = runListT do
+logList l = runListTRec do
   liftEff $ log "logging listT"
   str <- l
   liftEff $ log str
@@ -24,8 +23,8 @@ sumSqrs :: forall eff.
 -> ListT (Eff (console :: CONSOLE | eff)) Unit
 sumSqrs n = do
   let
-    nats = L.iterate (add one) zero -- lazy infinite list
-    squares = L.toUnfoldable <<< L.takeWhile (_ <= n) $ map (\x -> x * x) nats
+    nats = iterate (add one) zero
+    squares = takeWhile (_ <= n) $ map (\x -> x * x) nats
   x <- squares
   y <- squares
   liftEff $ log ("<" <> show x <> "," <> show y <> ">")
@@ -35,4 +34,4 @@ sumSqrs n = do
 main :: forall eff. Eff (console :: CONSOLE | eff) Unit
 main = do
   logList $ A.toUnfoldable ["one", "two", "three"]
-  runListT $ sumSqrs 10
+  runListTRec $ sumSqrs 10

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -11,6 +11,7 @@ import Example.State as State
 import Example.StateEff as StateEff
 import Example.Writer as Writer
 import Example.RWS as RWS
+import Example.List as List
 
 main :: Eff (console :: CONSOLE) Unit
 main = do
@@ -20,3 +21,4 @@ main = do
   StateEff.main
   Writer.main
   RWS.main
+  List.main


### PR DESCRIPTION
Addresses #83 

Following @kozak's suggestion, this exports `runListT` with the type `forall f a. Monad f => ListT f a -> f Unit`.

It also adds some instructive examples of its use to the tests.