### PR TITLE
Fix typo

### DIFF
--- a/src/Control/Monad/RWS/Trans.purs
+++ b/src/Control/Monad/RWS/Trans.purs
@@ -27,7 +27,7 @@ import Data.Tuple (Tuple(..), uncurry)
 data RWSResult state result writer = RWSResult state result writer
 
 -- | The reader-writer-state monad transformer, which combines the operations
--- | of `RWST`, `WriterT` and `StateT` into a single monad transformer.
+-- | of `ReaderT`, `WriterT` and `StateT` into a single monad transformer.
 newtype RWST r w s m a = RWST (r -> s -> m (RWSResult s a w))
 
 -- | Run a computation in the `RWST` monad.


### PR DESCRIPTION
The `R` in `RWST` stands for `ReaderT`, not `RWST`.

This appears to happened by accident in:
1c0a25383fab8997f6bb92e7af6f53dc43266cb9.