### PR TITLE
Fix documentation to use Effect instead of Eff

### DIFF
--- a/src/Control/Monad/Cont/Class.purs
+++ b/src/Control/Monad/Cont/Class.purs
@@ -15,7 +15,7 @@ import Prelude (class Monad)
 -- | For example:
 -- |
 -- | ```purescript
--- | delay :: forall eff. Number -> ContT Unit (Eff (timeout :: Timeout | eff)) Unit
+-- | delay :: Number -> ContT Unit Effect Unit
 -- | delay n = callCC \cont ->
 -- |   lift $ setTimeout n (runContT (cont unit) (\_ -> return unit))
 -- | ```


### PR DESCRIPTION
Using the old `Eff` construct in the documentation might be jarring to newcomers, and might give the impression that this lib is unmaintained.