### PR TITLE
Lazy instances for the remaining transformers

### DIFF
--- a/src/Control/Comonad/Env/Trans.purs
+++ b/src/Control/Comonad/Env/Trans.purs
@@ -7,10 +7,10 @@ import Prelude
 import Control.Comonad (class Comonad, extract)
 import Control.Comonad.Trans.Class (class ComonadTrans)
 import Control.Extend (class Extend, (<<=))
-
+import Control.Lazy (class Lazy)
+import Data.Newtype (class Newtype)
 import Data.Traversable (class Traversable, class Foldable, foldl, foldr, foldMap, traverse, sequence)
 import Data.Tuple (Tuple(..))
-import Data.Newtype (class Newtype)
 
 -- | The environment comonad transformer.
 -- |
@@ -45,6 +45,8 @@ instance comonadEnvT :: Comonad w => Comonad (EnvT e w) where
 
 instance comonadTransEnvT :: ComonadTrans (EnvT e) where
   lower (EnvT (Tuple e x)) = x
+
+derive newtype instance lazyEnvT :: (Lazy e, Lazy (w a)) => Lazy (EnvT e w a)
 
 instance foldableEnvT :: Foldable f => Foldable (EnvT e f) where
   foldl fn a (EnvT (Tuple _ x)) = foldl fn a x

--- a/src/Control/Comonad/Store/Trans.purs
+++ b/src/Control/Comonad/Store/Trans.purs
@@ -7,9 +7,9 @@ import Prelude
 import Control.Comonad (class Comonad, extract)
 import Control.Comonad.Trans.Class (class ComonadTrans)
 import Control.Extend (class Extend, (<<=))
-
-import Data.Tuple (Tuple(..))
+import Control.Lazy (class Lazy)
 import Data.Newtype (class Newtype)
+import Data.Tuple (Tuple(..))
 
 -- | The store comonad transformer.
 -- |
@@ -36,3 +36,5 @@ instance comonadStoreT :: Comonad w => Comonad (StoreT s w) where
 
 instance comonadTransStoreT :: ComonadTrans (StoreT s) where
   lower (StoreT (Tuple w s)) = (_ $ s) <$> w
+
+derive newtype instance lazyStoreT :: (Lazy (w (s -> a)), Lazy s) => Lazy (StoreT s w a)

--- a/src/Control/Comonad/Traced/Trans.purs
+++ b/src/Control/Comonad/Traced/Trans.purs
@@ -7,6 +7,7 @@ import Prelude
 import Control.Comonad (class Comonad, extract)
 import Control.Comonad.Trans.Class (class ComonadTrans)
 import Control.Extend (class Extend, (<<=))
+import Control.Lazy (class Lazy)
 import Data.Newtype (class Newtype)
 
 -- | The cowriter comonad transformer.
@@ -34,3 +35,5 @@ instance comonadTracedT :: (Comonad w, Monoid t) => Comonad (TracedT t w) where
 
 instance comonadTransTracedT :: Monoid t => ComonadTrans (TracedT t) where
   lower (TracedT w) = (\f -> f mempty) <$> w
+
+derive newtype instance lazyTracedT :: Lazy (w (t -> a)) => Lazy (TracedT t w a)

--- a/src/Control/Monad/Cont/Trans.purs
+++ b/src/Control/Monad/Cont/Trans.purs
@@ -8,6 +8,7 @@ module Control.Monad.Cont.Trans
 
 import Prelude
 
+import Control.Lazy (class Lazy)
 import Control.Monad.Cont.Class (class MonadCont, callCC)
 import Control.Monad.Reader.Class (class MonadAsk, class MonadReader, ask, local)
 import Control.Monad.State.Class (class MonadState, state)
@@ -53,6 +54,9 @@ instance monadContT :: Monad m => Monad (ContT r m)
 
 instance monadTransContT :: MonadTrans (ContT r) where
   lift m = ContT (\k -> m >>= k)
+
+instance lazyContT :: Lazy (ContT r m a) where
+  defer f = ContT \k -> case f unit of ContT f' -> f' k
 
 instance monadEffectContT :: MonadEffect m => MonadEffect (ContT r m) where
   liftEffect = lift <<< liftEffect

--- a/src/Control/Monad/Except/Trans.purs
+++ b/src/Control/Monad/Except/Trans.purs
@@ -10,6 +10,7 @@ import Prelude
 
 import Control.Alt (class Alt)
 import Control.Alternative (class Alternative)
+import Control.Lazy (class Lazy)
 import Control.Monad.Cont.Class (class MonadCont, callCC)
 import Control.Monad.Error.Class (class MonadThrow, class MonadError, throwError, catchError)
 import Control.Monad.Reader.Class (class MonadAsk, class MonadReader, ask, local)
@@ -100,6 +101,8 @@ instance monadTransExceptT :: MonadTrans (ExceptT e) where
   lift m = ExceptT do
     a <- m
     pure $ Right a
+
+derive newtype instance lazyExceptT :: Lazy (m (Either e a)) => Lazy (ExceptT e m a)
 
 instance monadEffectExceptT :: MonadEffect m => MonadEffect (ExceptT e m) where
   liftEffect = lift <<< liftEffect

--- a/src/Control/Monad/List/Trans.purs
+++ b/src/Control/Monad/List/Trans.purs
@@ -40,6 +40,7 @@ import Prelude
 
 import Control.Alt (class Alt)
 import Control.Alternative (class Alternative)
+import Control.Lazy (class Lazy)
 import Control.Monad.Rec.Class as MR
 import Control.Monad.Trans.Class (class MonadTrans, lift)
 import Control.MonadPlus (class MonadPlus)
@@ -313,6 +314,9 @@ instance monadListT :: Monad f => Monad (ListT f)
 
 instance monadTransListT :: MonadTrans ListT where
   lift = fromEffect
+
+instance lazyListT :: Applicative f => Lazy (ListT f a) where
+  defer f = ListT <<< pure $ Skip (defer f)
 
 instance altListT :: Applicative f => Alt (ListT f) where
   alt = concat

--- a/src/Control/Monad/Maybe/Trans.purs
+++ b/src/Control/Monad/Maybe/Trans.purs
@@ -9,6 +9,7 @@ import Prelude
 
 import Control.Alt (class Alt)
 import Control.Alternative (class Alternative)
+import Control.Lazy (class Lazy)
 import Control.Monad.Cont.Class (class MonadCont, callCC)
 import Control.Monad.Error.Class (class MonadThrow, class MonadError, catchError, throwError)
 import Control.Monad.Reader.Class (class MonadAsk, class MonadReader, ask, local)
@@ -59,6 +60,8 @@ instance monadMaybeT :: Monad m => Monad (MaybeT m)
 
 instance monadTransMaybeT :: MonadTrans MaybeT where
   lift = MaybeT <<< liftM1 Just
+
+derive newtype instance lazyMaybeT :: Lazy (m (Maybe a)) => Lazy (MaybeT m a)
 
 instance altMaybeT :: Monad m => Alt (MaybeT m) where
   alt (MaybeT m1) (MaybeT m2) = MaybeT do

--- a/src/Control/Monad/Reader/Trans.purs
+++ b/src/Control/Monad/Reader/Trans.purs
@@ -11,6 +11,7 @@ import Prelude
 import Control.Alt (class Alt, (<|>))
 import Control.Alternative (class Alternative)
 import Control.Apply (lift2)
+import Control.Lazy (class Lazy)
 import Control.Monad.Cont.Class (class MonadCont, callCC)
 import Control.Monad.Error.Class (class MonadThrow, class MonadError, catchError, throwError)
 import Control.Monad.Reader.Class (class MonadAsk, class MonadReader, ask, asks, local)
@@ -82,6 +83,8 @@ instance monadPlusReaderT :: MonadPlus m => MonadPlus (ReaderT r m)
 
 instance monadTransReaderT :: MonadTrans (ReaderT r) where
   lift = ReaderT <<< const
+
+derive newtype instance lazyReaderT :: Lazy (ReaderT r m a)
 
 instance monadEffectReader :: MonadEffect m => MonadEffect (ReaderT r m) where
   liftEffect = lift <<< liftEffect

--- a/src/Control/Monad/Writer/Trans.purs
+++ b/src/Control/Monad/Writer/Trans.purs
@@ -10,6 +10,7 @@ import Prelude
 
 import Control.Alt (class Alt, (<|>))
 import Control.Alternative (class Alternative)
+import Control.Lazy (class Lazy)
 import Control.Monad.Cont.Class (class MonadCont, callCC)
 import Control.Monad.Error.Class (class MonadThrow, class MonadError, catchError, throwError)
 import Control.Monad.Reader.Class (class MonadAsk, class MonadReader, ask, local)
@@ -92,6 +93,8 @@ instance monadTransWriterT :: Monoid w => MonadTrans (WriterT w) where
   lift m = WriterT do
     a <- m
     pure $ Tuple a mempty
+
+derive newtype instance lazyWriterT :: Lazy (m (Tuple a w)) => Lazy (WriterT w m a)
 
 instance monadEffectWriter :: (Monoid w, MonadEffect m) => MonadEffect (WriterT w m) where
   liftEffect = lift <<< liftEffect


### PR DESCRIPTION
Saw there were a few missing Lazy instances when i needed `Lazy ContT` for something i wanted to try. I added a `Lazy` instance to all the transformers that didn't have one (i think i did, anyway. let me know if anything's missing).