### PR TITLE
Fix documentation for callCC

### DIFF
--- a/src/Control/Monad/Cont/Class.purs
+++ b/src/Control/Monad/Cont/Class.purs
@@ -15,9 +15,11 @@ import Prelude (class Monad)
 -- | For example:
 -- |
 -- | ```purescript
+-- | -- setTimeout :: Number -> Effect Unit -> Effect Unit
+-- |
 -- | delay :: Number -> ContT Unit Effect Unit
 -- | delay n = callCC \cont ->
--- |   lift $ setTimeout n (runContT (cont unit) (\_ -> return unit))
+-- |   lift $ setTimeout n (runContT (cont unit) (\_ -> pure unit))
 -- | ```
 -- | An implementation is provided for `ContT`, and for other monad transformers
 -- | defined in this library.


### PR DESCRIPTION
Fixed: `return` -> `pure`
Added a type signature to `setTimeout`: If someone is trying to figure out what's going on here and they look up `setTimeout` on pursuit, they will find `setTimeout :: Int -> Effect Unit -> Effect TimeoutId` in `js-timers`, which does not work here at all. The added type signature shows we are intentionally using a simplified version of the function.