### PR TITLE
Error.Class: add convenice lifting functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+ - Add `liftMaybe` and `liftEither` to easily lift `Maybe` and `Either` values
+   to a `MonadThrow` monad.
 
 Bugfixes:
 

--- a/src/Control/Monad/Error/Class.purs
+++ b/src/Control/Monad/Error/Class.purs
@@ -4,8 +4,8 @@ module Control.Monad.Error.Class where
 
 import Prelude
 
-import Data.Maybe (Maybe(..))
 import Data.Either (Either(..), either)
+import Data.Maybe (Maybe(..), maybe)
 import Effect (Effect)
 import Effect.Exception as Ex
 
@@ -102,3 +102,11 @@ withResource acquire release kleisli = do
   result <- try $ kleisli resource
   release resource
   either throwError pure result
+
+-- | Lift a `Maybe` value to a MonadThrow monad.
+liftMaybe :: forall m e a. MonadThrow e m => e -> Maybe a -> m a
+liftMaybe error = maybe (throwError error) pure
+
+-- | Lift an `Either` value to a MonadThrow monad.
+liftEither :: forall m e a. MonadThrow e m => Either e a -> m a
+liftEither = either throwError pure


### PR DESCRIPTION
Add functions that allow `Either` and `Maybe` to be easily lifted to a
MonadThrow monad.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
